### PR TITLE
Add priority prefixes to echo messages

### DIFF
--- a/etc/greenboot/green.d/00_greenboot_notification.sh
+++ b/etc/greenboot/green.d/00_greenboot_notification.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "Health Check SUCCESS! Boot status is GREEN"
+echo "<5>Health Check SUCCESS! Boot status is GREEN"

--- a/etc/greenboot/red.d/00_redboot_notification.sh
+++ b/etc/greenboot/red.d/00_redboot_notification.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "Health Check FAILURE! Boot status is RED"
+echo "<0>Health Check FAILURE! Boot status is RED"

--- a/usr/libexec/greenboot/greenboot.sh
+++ b/usr/libexec/greenboot/greenboot.sh
@@ -14,14 +14,14 @@ script_runner () {
       local failure_msg="Script '$(basename $script)' FAILURE (exit code '$rc')"
       case "$mode" in
         "relaxed")
-          echo "$failure_msg. Continuing..." >&2
+          echo "<2>$failure_msg. Continuing..." >&2
           ;;
         "strict")
-          echo "$failure_msg" >&2
+          echo "<0>$failure_msg" >&2
           exit $rc
       esac
     else
-      echo "Script '$(basename $script)' SUCCESS"
+      echo "<5>Script '$(basename $script)' SUCCESS"
     fi
   done
 }


### PR DESCRIPTION
Adds boldness/color to their corresponding journal logs.

What priority level do you feel is adequate for which case? @jlebon @dustymabe @nullr0ute 

from syslog(3), levels 0-7:
```
       This determines the importance of the message.  The levels are, in
       order of decreasing importance:

       LOG_EMERG      system is unusable

       LOG_ALERT      action must be taken immediately

       LOG_CRIT       critical conditions

       LOG_ERR        error conditions

       LOG_WARNING    warning conditions

       LOG_NOTICE     normal, but significant, condition

       LOG_INFO       informational message

       LOG_DEBUG      debug-level message
```