### PR TITLE
Guard against boot looping

### DIFF
--- a/greenboot.spec
+++ b/greenboot.spec
@@ -1,5 +1,5 @@
 Name:               greenboot
-Version:            0.7
+Version:            0.8
 Release:            1%{?dist}
 Summary:            Generic Health Check Framework for systemd
 License:            LGPLv2+
@@ -76,6 +76,7 @@ install -DpZm 0755 usr/libexec/greenboot/greenboot %{buildroot}%{_libexecdir}/%{
 install -DpZm 0755 usr/libexec/greenboot/greenboot-grub2-set-counter %{buildroot}%{_libexecdir}/%{name}/greenboot-grub2-set-counter
 install -DpZm 0755 usr/libexec/greenboot/greenboot-rpm-ostree-grub2-check-fallback %{buildroot}%{_libexecdir}/%{name}/greenboot-rpm-ostree-grub2-check-fallback
 install -DpZm 0755 usr/libexec/greenboot/greenboot-status %{buildroot}%{_libexecdir}/%{name}/greenboot-status
+install -DpZm 0755 usr/libexec/greenboot/redboot-auto-reboot-check %{buildroot}%{_libexecdir}/%{name}/redboot-auto-reboot-check
 install -DpZm 0644 usr/lib/motd.d/boot-status %{buildroot}%{_exec_prefix}/lib/motd.d/boot-status
 install -DpZm 0644 usr/lib/systemd/system/* %{buildroot}%{_unitdir}
 install -DpZm 0644 usr/lib/tmpfiles.d/greenboot-status-motd.conf %{buildroot}%{_tmpfilesdir}/greenboot-status-motd.conf
@@ -167,9 +168,14 @@ install -DpZm 0755 etc/greenboot/check/wanted.d/* %{buildroot}%{_sysconfdir}/%{n
 %{_unitdir}/greenboot-grub2-set-counter.service
 
 %files reboot
+%{_libexecdir}/%{name}/redboot-auto-reboot-check
 %{_unitdir}/redboot-auto-reboot.service
 
 %changelog
+* Wed Feb 05 2020 Christian Glombek <lorbus@fedoraproject.org> - 0.8-1
+- Update to v0.8
+- Add guard against bootlooping in redboot-auto-reboot.service
+
 * Mon Apr 01 2019 Christian Glombek <lorbus@fedoraproject.org> - 0.7-1
 - Update to v0.7
 - Rename ostree-grub2 subpackage to  rpm-ostree-grub2 to be more explicit

--- a/usr/lib/systemd/system/redboot-auto-reboot.service
+++ b/usr/lib/systemd/system/redboot-auto-reboot.service
@@ -14,5 +14,10 @@ After=redboot.service
 Wants=redboot.service
 SuccessAction=reboot
 
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/greenboot/redboot-auto-reboot-check
+
 [Install]
 WantedBy=redboot.target

--- a/usr/libexec/greenboot/greenboot-status
+++ b/usr/libexec/greenboot/greenboot-status
@@ -12,6 +12,11 @@ else
     status+="$(journalctl -u redboot.service -p 0 -b -0 -o cat)"$'\n'
     # healthcheck logs from current boot
     status+="$(journalctl -u greenboot-healthcheck.service -p 2 -b -0 -o cat)"$'\n'
+    # redboot-auto-reboot.service logs from current boot
+    reboot_info="$(journalctl -u redboot-auto-reboot -p 1 -b -0 -o cat)"||""
+    if [ -n "$reboot_info" ]; then
+        status+="$reboot_info"
+    fi
 fi
 
 if [ -z "$status" ]; then
@@ -20,7 +25,7 @@ fi
 
 # TODO: Show initial/max and current boot_counter values in status
 # If this is a fallback boot (i.e. the countdown has reached its end), show logs from previous boot
-fallback_info="$(journalctl -u greenboot-rpm-ostree-grub2-check-fallback -b -0 -p 3 -o cat)"
+fallback_info="$(journalctl -u greenboot-rpm-ostree-grub2-check-fallback -b -0 -p 3 -o cat)"||""
 if [ -n "$fallback_info" ]; then
     status+="$fallback_info"
 fi

--- a/usr/libexec/greenboot/redboot-auto-reboot-check
+++ b/usr/libexec/greenboot/redboot-auto-reboot-check
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+# In case we've booted into our fallback deployment and still don't reach boot-complete.target, do nothing.
+if grub2-editenv list | grep -q "^boot_counter=-1$"; then
+  echo "<0>FALLBACK BOOT DETECTED but SYSTEM is still UNHEALTHY. Cannot proceed."
+  exit 1
+fi
+
+echo "<1>SYSTEM is UNHEALTHY. Rebooting..."


### PR DESCRIPTION
by checking whether boot_counter has reached -1 before rebooting.
If true, it is implied that the the fallback boot entry is already
booted, but also failed to reach boot-complete.target like the
previously tried entry.
Echo a warning to the journal and do nothing more in this case
to avoid bootlooping forever.

Fixes: #26 